### PR TITLE
Added constexpr to needed function declarations

### DIFF
--- a/src/rng.hpp
+++ b/src/rng.hpp
@@ -52,8 +52,8 @@ namespace anka {
         }
 
         // C++ UniformRandomBitGenerator interface methods
-        force_inline static result_type min() { return C64(0); }
-        force_inline static result_type max() { return UINT64_MAX; }
+        force_inline constexpr static result_type min() { return C64(0); }
+        force_inline constexpr static result_type max() { return UINT64_MAX; }
         force_inline result_type operator()() { return rand64(); }
     private:
 


### PR DESCRIPTION
Fixes a compile error I came across when building this program for Linux. This should theoretically resolve #8, although I'm not certain of their particular details. I attempted to build for Windows as well, but couldn't figure out how to use VSCode, although nothing should break with this change.